### PR TITLE
Bumped version of byteorder and libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ homepage = "https://github.com/vasi/positioned-io"
 readme = "README.md"
 
 [dependencies]
-byteorder = "0.5"
+byteorder = "1.2"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.14"
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"


### PR DESCRIPTION
Updated the versions of `byteorder` and `libc` to be the latest versions. Also removed the minor version to preventing having to update more frequently.