### PR TITLE
Update to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,4 @@ byteorder = "1.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3", features = ["minwindef", "minwinbase", "fileapi", "winnt"] }


### PR DESCRIPTION
This would be nice to have because winapi 0.3 is much lighter. Also no longer requires kernel32-sys.