### PR TITLE
feat: Slice::into_inner, Slice::offset etc

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -72,6 +72,31 @@ impl<I> Slice<I> {
             Some(size) => min(bytes as u64, size - pos) as usize,
         }
     }
+
+    /// Consumes the slice, returning the underlying value.
+    pub fn into_inner(self) -> I {
+        self.io
+    }
+    /// Get a reference to the underlying value in this slice.
+    ///
+    /// Note that IO on the returned value may escape the slice.
+    pub fn get_ref(&self) -> &I {
+        &self.io
+    }
+    /// Get a mutable reference to the underlying value in this slice.
+    ///
+    /// Note that IO on the returned value may escape the slice.
+    pub fn get_mut(&mut self) -> &mut I {
+        &mut self.io
+    }
+    /// Get the offset that this slice starts at within the underlying IO.
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+    /// Set the offset that this slice starts at within the underlying IO.
+    pub fn set_offset(&mut self, offset: u64) {
+        self.offset = offset
+    }
 }
 impl<I: Size> Slice<I> {
     /// Create a new `Slice` that goes to the end of `io`.


### PR DESCRIPTION
Thanks for maintaining this library!

[`Cursor`](https://docs.rs/positioned-io/0.3.2/positioned_io/struct.Cursor.html) has the following methods, but their analogues are missing on [`Slice`](https://docs.rs/positioned-io/0.3.2/positioned_io/struct.Slice.html):
https://github.com/vasi/positioned-io/blob/1cb70389b133f1e96c68279b04c6baf618e6ca22/src/cursor.rs#L77-L105

This PR adds those - my use-case includes type erasing the inner reader on-demand.

As with to #22, much obliged if you would release a minor version :)