### PR TITLE
Implement `ReadAt` and `Size` for `Arc<RandomAccessFile>`

### DIFF
--- a/src/raf.rs
+++ b/src/raf.rs
@@ -4,7 +4,7 @@ use std::io::{Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
-use std::{fs::File, io, io::Write, path::Path};
+use std::{fs::File, io, io::Write, path::Path, sync::Arc};
 
 use super::{ReadAt, Size, WriteAt};
 
@@ -149,5 +149,19 @@ impl WriteAt for RandomAccessFile {
 impl Size for RandomAccessFile {
     fn size(&self) -> io::Result<Option<u64>> {
         self.file.size()
+    }
+}
+
+impl ReadAt for Arc<RandomAccessFile> {
+    #[inline]
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+        (**self).read_at(pos, buf)
+    }
+}
+
+impl Size for Arc<RandomAccessFile> {
+    #[inline]
+    fn size(&self) -> io::Result<Option<u64>> {
+        (**self).size()
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,6 +3,7 @@ use std::{
     fs::File,
     io::{Error, ErrorKind, Read, Result, Seek, SeekFrom},
     str,
+    sync::Arc,
 };
 
 #[cfg(feature = "byteorder")]
@@ -116,6 +117,22 @@ fn test_size_cursor() {
     assert_eq!(2, curs.read(&mut buf).unwrap());
     let s = str::from_utf8(buf.as_ref()).unwrap();
     assert!(s.contains("\n"));
+}
+
+#[test]
+fn test_clone_size_cursor() {
+    let file = Arc::new(RandomAccessFile::open("tests/pi.txt").unwrap());
+    let mut curs = SizeCursor::new(file);
+    let mut curs_copy = curs.clone();
+
+    let mut buf = [0; 4];
+    assert_eq!(4, curs.read(&mut buf).unwrap());
+    let s = str::from_utf8(buf.as_ref()).unwrap();
+    assert_eq!(s, "3.14");
+
+    assert_eq!(4, curs_copy.read(&mut buf).unwrap());
+    let s = str::from_utf8(buf.as_ref()).unwrap();
+    assert_eq!(s, "3.14");
 }
 
 #[test]


### PR DESCRIPTION
`Arc<RandomAccessFile>` is useful because it can be cloned, and `ReadAt` and `Size` are not mutating operations. `SizeCursor<Arc<RandomAccessFile>>` can be cloned and shared across threads and also act like a file with a mutable seek position.

A more specific example is creating a `zip::ZipArchive<SizeCursor<Arc<RandomAccessFile>>>` instance and cloning a copy per thread.

https://docs.rs/zip/1.1.4/zip/read/struct.ZipArchive.html