### PR TITLE
feat: compile without unix/windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+          targets: wasm32-unknown-unknown
       - run: cargo test
       - run: cargo doc
+      - run: cargo check --target wasm32-unknown-unknown

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,9 @@ mod unix;
 mod windows;
 
 // RandomAccess file wrapper.
+#[cfg(any(windows, unix))]
 mod raf;
+#[cfg(any(windows, unix))]
 pub use crate::raf::RandomAccessFile;
 
 // Implementation for arrays, vectors.


### PR DESCRIPTION
The traits from this module are useful even in non-native (unix/windows) contexts, e.g. on wasm. Currently however the `raf` module fails to compile if neither `windows` nor `unix` cfg is active.
This adds feature flags to the `raf` modules to only compile if either `unix` or `windows` is active.